### PR TITLE
Add mobile nav, party sync, and tips

### DIFF
--- a/index.html
+++ b/index.html
@@ -1485,6 +1485,7 @@
     const questLog = JSON.parse(localStorage.getItem('questLog') || '[]');
     let partyName = localStorage.getItem('partyName') || '';
     const partyPresence = JSON.parse(localStorage.getItem('partyPresence') || '{}');
+    updatePartyStatus();
     const quests = [
       "Take a silly photo on the next ride",
       "Each person finds something green",
@@ -2101,12 +2102,18 @@
       localStorage.removeItem("seenCharlieWelcome");
       location.reload();
     }
+    function updateThemeIcon() {
+      const btn = document.getElementById('theme-toggle');
+      if (btn) btn.textContent = document.body.classList.contains('light') ? '🌞' : '🌙';
+    }
     function toggleTheme() {
       document.body.classList.toggle('light');
       localStorage.setItem('theme', document.body.classList.contains('light') ? 'light' : 'dark');
+      updateThemeIcon();
     }
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme === 'light') document.body.classList.add('light');
+    updateThemeIcon();
     document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
   </script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>


### PR DESCRIPTION
## Summary
- add sticky nav with dark-mode toggle
- show food highlights and park tips per park
- enhance Party Mode with shared party name and check-in
- add footer and mobile theme toggle

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6878c6d7a9808330b4dbc6f062400491