### PR TITLE
Fix navigation link to Magic Kingdom page

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,10 +539,10 @@
       <button class="back-btn" onclick="goHome()">← Back</button>
       <div class="park-title">🏰 Disney Parks</div>
       <div class="main-menu-grid">
-        <button class="menu-btn" onclick="openPark('MK')">
+        <a class="menu-btn" href="magic-kingdom.html">
           <span class="emoji">🏰</span>
           <span>Magic Kingdom</span>
-        </button>
+        </a>
         <button class="menu-btn" onclick="openPark('EPCOT')">
           <span class="emoji">🌐</span>
           <span>EPCOT</span>
@@ -850,9 +850,18 @@
       html.style.scrollBehavior = prevBehavior;
     }
 
+    function handleHashNavigation() {
+      const id = location.hash.slice(1);
+      if (id) {
+        showPage(id);
+      }
+    }
+    window.addEventListener('hashchange', handleHashNavigation);
+    document.addEventListener('DOMContentLoaded', handleHashNavigation);
+
     // Navigation functions
     function openPark(park) {
-      showPage('park-' + park);
+      location.hash = 'park-' + park;
     }
     function openPlanner() {
       showPage('planner-page');

--- a/magic-kingdom.html
+++ b/magic-kingdom.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=index.html#park-MK">
+  <title>Magic Kingdom</title>
+</head>
+<body>
+  <p>Redirecting to Magic Kingdom...</p>
+  <p>If you are not redirected, <a href="index.html#park-MK">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert `Magic Kingdom` menu button into an `<a>` link
- update `openPark()` to update the URL hash
- read the hash on load/when changed to show the correct page
- add a simple `magic-kingdom.html` redirector page

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6878ccb7a72c83309d77f335daa1eb6b